### PR TITLE
feat: support to byreal and pancankeswap

### DIFF
--- a/src/abi/byreal_clmm/index.ts
+++ b/src/abi/byreal_clmm/index.ts
@@ -1,0 +1,5 @@
+export * as instructions from '../raydium_clmm/instructions'
+export * as events from '../raydium_clmm/events'
+export * as types from '../raydium_clmm/types'
+
+export const programId = 'REALQqNEomY6cQGZJUGwywTBD2UmDT32rZcNnfxQ5N2'

--- a/src/abi/pancake_clmm/index.ts
+++ b/src/abi/pancake_clmm/index.ts
@@ -1,0 +1,5 @@
+export * as instructions from '../raydium_clmm/instructions'
+export * as events from '../raydium_clmm/events'
+export * as types from '../raydium_clmm/types'
+
+export const programId = 'HpNfyc2Saw7RKkQd8nEL4khUcuPhQ7WwY1B2qjx8jxFq'

--- a/src/streams/swaps/handlers/raydium/clmm.ts
+++ b/src/streams/swaps/handlers/raydium/clmm.ts
@@ -10,9 +10,15 @@ import {
 } from '../../../../utils';
 import * as raydiumClmm from '../../../../abi/raydium_clmm';
 import type { SwapEvent } from '../../../../abi/raydium_clmm/types';
-import type { SolanaSwapTransfer, TokenAmount } from '../../';
+import type { SolanaSwapTransfer, SwapType, TokenAmount } from '../../';
 
-export function handleRaydiumClmm(ins: Instruction, block: Block): SolanaSwapTransfer {
+type RaydiumForks = Extract<SwapType, 'raydium_clmm' | 'byreal_clmm' | 'pancake_clmm'>
+
+export function handleRaydiumClmm(
+  ins: Instruction,
+  block: Block,
+  fork: RaydiumForks = 'raydium_clmm',
+): SolanaSwapTransfer {
   const {
     accounts: { poolState: poolAddress, inputVault, outputVault },
   } = decodeSwap(ins);


### PR DESCRIPTION
depends on #5 

Byreal and PancakeSwap are forks of Raydium CLMM, so no extra decoding logic is needed to support both protocol.